### PR TITLE
chore(): remove broken dark mode until we have a design

### DIFF
--- a/src/assets/css/base.css
+++ b/src/assets/css/base.css
@@ -38,21 +38,6 @@
   --light-primary-color: rgba(255, 255, 255, 0.6);
 }
 
-/* blockquote, dl, dd, h1, h2, h3, h4, h5, h6, hr, figure, p, pre {
-  
-} */
-
-/* Dark mode */
-@media (prefers-color-scheme: dark) {
-  :root {
-    --primary-font-color: #ffffff;
-    --secondary-font-color: #eeeeee;
-
-    --primary-background-color: #000000;
-    --secondary-background-color: #292c3a;
-  }
-}
-
 * {
   box-sizing: border-box;
 }
@@ -114,12 +99,6 @@ li > a {
 a {
   color:#342a6a;
   text-decoration: underline;
-}
-
-@media (prefers-color-scheme: dark) {
-  a {
-    color: var(--link-color);
-  }
 }
 
 ol, ul {

--- a/src/includes/sub-header.njk
+++ b/src/includes/sub-header.njk
@@ -1,5 +1,5 @@
 <section
-  class="sub-header dark:bg-secondary flex flex-col relative bg-cover bg-center bg-no-repeat min-h-64 mb-8"
+  class="sub-header light:bg-secondary flex flex-col relative bg-cover bg-center bg-no-repeat min-h-64 mb-8"
   role="sub-header"
 >
   <div class="container mx-auto px-8">


### PR DESCRIPTION
This code removes the dark mode CSS until we have a proper dark mode design. Text and links on dark mode were almost unreadable at points and did not meet accessibility expectations. Because of this I removed the existing dark mode CSS until we have a legit dark mode design. The blog now looks exactly the same on a dark mode PC as it does in light mode (triple checked with devtools:

![image](https://user-images.githubusercontent.com/8823093/125532777-c340cc68-ae7b-42b3-a9e3-9474388b5b14.png)
![image](https://user-images.githubusercontent.com/8823093/125532814-754310f3-7381-4d8e-8586-1ea2ca26b3f8.png)

