### PR TITLE
rearranged some of the aria stuff so that we keep the foxus when tabb…

### DIFF
--- a/src/includes/sub-header.njk
+++ b/src/includes/sub-header.njk
@@ -12,11 +12,11 @@
       >
         {% if isPost or isDocumentation %}
           {% if isPost %}
-            <a class="inline-flex items-center subheaderA" href="{{ backUrl }}">
-            <ion-icon class="mr-1" name="chevron-back-outline" aria-label="Link back to Blog Home"></ion-icon>Back</a>
+            <a class="inline-flex items-center subheaderA" href="{{ backUrl }}" aria-label="Link back to Blog Home">
+            <ion-icon class="mr-1" name="chevron-back-outline" aria-hidden="true"></ion-icon>Back</a>
           {% else %}
-            <a class="inline-flex items-center subheaderA" href="{{ backUrl }}">
-              <ion-icon class="mr-1" name="chevron-back-outline" aria-label="Link back to Documentation Home"></ion-icon>Back</a>
+            <a class="inline-flex items-center subheaderA" href="{{ backUrl }}" aria-label="Link back to Documentation Home">
+              <ion-icon class="mr-1" name="chevron-back-outline" aria-hidden="true"></ion-icon>Back</a>
             {% endif %}
         {% else %}
           <p>PWA Builder Resource Hub</p>


### PR DESCRIPTION
Fixes
https://microsoft.visualstudio.com/OS/_sprints/backlog/PWA%20Builder%20Team/OS/2110?workitem=35277094

PR Type
Bug Fix

Describe the current behavior?
Narrator describes the chevron in the subheader as well as the word "Back" when in scan mode. This can be confusing to a user when announced twice

Describe the new behavior?
I moved the aria-label to the <a> tag that holds the chevron and the word Back and hid the aria of the chevron. Now the narrator only lands on the word "Back" in scan mode which announces "link back to Blog/Documentation" home and when tabbing both the chevron and Back are blocked together.

Additional Information
