### PR TITLE
IOS blog missing logo alt tag added

### DIFF
--- a/src/docs/ios/ios-platform/ios-platform.md
+++ b/src/docs/ios/ios-platform/ios-platform.md
@@ -19,7 +19,7 @@ tags:
   - iOS
 ---
 
-<img src="/docs/ios/ios-platform/ios-store-logo.png" style="max-height: 250px;" />
+<img src="/docs/ios/ios-platform/ios-store-logo.png" style="max-height: 250px;" alt="Ios Store Logo"/>
 
 The PWABuilder iOS platform is an experimental project that utilizes a Webkit-based web view (WKWebView) to load your PWA on iOS and enable some PWA functionality. 
 


### PR DESCRIPTION
Ticket: https://github.com/pwa-builder/PWABuilder/issues/2616